### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ steps:
   - label:   "Retrieve and use an env var"
     command: echo "The value was $FOO"
     plugins:
-      vital-software/metadata-env#0.0.1:
-        get: [FOO]
+      - vital-software/metadata-env#0.0.1:
+          get: [FOO]
 ```
 
 ## Configuration


### PR DESCRIPTION
Hi @dominics! 😊

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.