### PR TITLE
Bug/Variables with special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ build metadata, if set, and used for the current command.
   post-command hook won't have access to it. Suggestions for working around
   that are welcome.
 
+## Developing
+
+To run the tests:
+
+```bash
+docker-compose run --rm tests
+```
+
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/environment
+++ b/hooks/environment
@@ -27,6 +27,6 @@ for var in ${vars[@]+"${vars[@]}"}; do
     echo "Value for ${var} is missing or empty in build metadata - not setting variable" >&2
   else
     echo "Retrieved ${var}=${value} from build metadata" >&2
-    export ${var}=${value}
+    export "${var}"="${value}"
   fi
 done

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -23,6 +23,20 @@ export BUILDKITE_AGENT_METADATA_ENV_DEBUG=/dev/tty
   unset BUILDKITE_PLUGIN_METADATA_ENV_GET_1
 }
 
+@test "Environment gets build metadata with spaces" {
+  stub buildkite-agent \
+    "meta-data get env-SPACE : echo Contains some spaces"
+
+    export BUILDKITE_PLUGIN_METADATA_ENV_GET_0="SPACE"
+
+    run "$PWD/tests/space-as-expected"
+
+    assert_output --partial "Environment Variable SPACE: 'Contains some spaces' as expected"
+
+    unstub buildkite-agent
+    unset BUILDKITE_PLUGIN_METADATA_ENV_GET_0
+}
+
 @test "Environment copes with missing metadata" {
   stub buildkite-agent \
     "meta-data get env-MISSING : echo 'Failed to get metadata metadata-env-plugin-API_VERSION' >&2 && exit 1"

--- a/tests/space-as-expected
+++ b/tests/space-as-expected
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# BATS cannot assert on environment variables set in a subshell
+# https://github.com/bats-core/bats-core/issues/168
+# This provides a wrapper so we can assert on environment variables set
+
+set -euo pipefail
+
+. "$PWD/hooks/environment"
+if [ "$SPACE" = "Contains some spaces" ] 
+then
+    echo "Environment Variable SPACE: '$SPACE' as expected"
+else
+    echo "Environment Variable SPACE: '$SPACE' is not expected"
+fi


### PR DESCRIPTION
# Purpose

Encountered an issue with metadata which contained special characters (like spaces) would either error or be saved as a environment variable without any characters after a space.

```
> Running plugin metadata-env environment hook
$ buildkite-agent meta-data get env-COMMIT_INFO_AUTHOR
Retrieved COMMIT_INFO_AUTHOR=Morris Nye from build metadata
# COMMIT_INFO_AUTHOR changed
> Running commands
$ env | grep COMMIT_INFO
COMMIT_INFO_AUTHOR=Morris
```

# Approach

- Documented in README.md how to run the tests
- Added a failing test for metadata to environment variable with spaces.
  - This test uses a small helper as BATS cannot assert on an environment variable set in a command
  - The helper is currently hardcoded for a single assertion
- Added quotes to the export command
